### PR TITLE
Ruby-style attributes - Issue #7

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -134,8 +134,9 @@ impl HtmlElement {
     }
 }
 
+#[derive(Debug)]
 pub struct Arena {
-    nodes: Vec<Node>,
+    nodes: Vec<Node>
 }
 
 impl Arena {
@@ -150,7 +151,6 @@ impl Arena {
 
     pub fn add_sibling(&mut self, current_id: usize, sibling_id: usize) {
         self.nodes[current_id].next_sibling = Some(sibling_id);
-        self.nodes[sibling_id].previous_sibling = Some(current_id);
     }
 
     pub fn parent(&self, id: usize) -> usize {
@@ -166,7 +166,6 @@ impl Arena {
         self.nodes.push(Node {
             parent: 0,
             children: vec![],
-            previous_sibling: None,
             next_sibling: None,
             data,
         });
@@ -180,7 +179,6 @@ impl Arena {
 
     fn node_to_html(&self, id: usize) -> String {
         let mut html_builder = String::new();
-
         let node = self.node_at(id);
         match node.data {
             Html::Element(ref ele) => {
@@ -198,8 +196,10 @@ impl Arena {
             }
             ref data => html_builder.push_str(&format!("{}{}", data.to_html(), common::newline())),
         }
+        if id == 0 {
         if let Some(sibling_id) = node.next_sibling() {
             html_builder.push_str(&format!("{}", self.node_to_html(sibling_id)));
+        }
         }
 
         html_builder
@@ -219,7 +219,6 @@ impl ToHtml for Arena {
 #[derive(Debug)]
 pub struct Node {
     parent: usize,
-    previous_sibling: Option<usize>,
     next_sibling: Option<usize>,
     children: Vec<usize>,
     data: Html,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -136,7 +136,7 @@ impl HtmlElement {
 
 #[derive(Debug)]
 pub struct Arena {
-    nodes: Vec<Node>
+    nodes: Vec<Node>,
 }
 
 impl Arena {
@@ -183,8 +183,10 @@ impl Arena {
         match node.data {
             Html::Element(ref ele) => {
                 html_builder.push_str(&format!("<{}", ele.tag()));
-                for (key, value) in ele.attributes().raw().iter() {
-                    html_builder.push_str(&format!(" {}='{}'", key, value.join(" ")));
+                for key in sort(ele.attributes().raw()) {
+                    if let Some(ref value) = ele.attributes().raw().get(&key) {
+                        html_builder.push_str(&format!(" {}=\'{}\'", key, value.join(" ")));
+                    }
                 }
                 html_builder.push_str(&format!(">{}", common::newline()));
 
@@ -197,9 +199,9 @@ impl Arena {
             ref data => html_builder.push_str(&format!("{}{}", data.to_html(), common::newline())),
         }
         if id == 0 {
-        if let Some(sibling_id) = node.next_sibling() {
-            html_builder.push_str(&format!("{}", self.node_to_html(sibling_id)));
-        }
+            if let Some(sibling_id) = node.next_sibling() {
+                html_builder.push_str(&format!("{}", self.node_to_html(sibling_id)));
+            }
         }
 
         html_builder
@@ -232,4 +234,13 @@ impl Node {
     pub fn children(&self) -> &Vec<usize> {
         &self.children
     }
+}
+
+fn sort(map: &HashMap<String, Vec<String>>) -> Vec<String> {
+    let mut v = vec![];
+    for key in map.keys() {
+        v.push(key.clone());
+    }
+    v.sort();
+    v
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -186,7 +186,7 @@ impl Arena {
             Html::Element(ref ele) => {
                 html_builder.push_str(&format!("<{}", ele.tag()));
                 for (key, value) in ele.attributes().raw().iter() {
-                    html_builder.push_str(&format!(" {}=\"{}\"", key, value.join(" ")));
+                    html_builder.push_str(&format!(" {}='{}'", key, value.join(" ")));
                 }
                 html_builder.push_str(&format!(">{}", common::newline()));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod values;
 
 use parser::Parser;
 use scanner::Scanner;
+use values::Token;
 
 /// Converts the Haml that is contained in a reference string
 /// into an owned string.
@@ -23,4 +24,9 @@ pub fn to_html(haml: &str) -> String {
     let mut parser = Parser::new(tokens);
     let parsed_values = parser.parse();
     generator::to_html(&parsed_values)
+}
+
+pub fn tokenize<'a>(haml: &'a str) -> Vec<Token> {
+    let mut scanner = Scanner::new(haml);
+    scanner.get_tokens().clone()
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -147,7 +147,7 @@ impl<'a> Parser<'a> {
         let mut id = "";
         loop {
             match self.tokens.next() {
-                Some(tok) => {println!("{:?}", tok); match tok {
+                Some(tok) => match tok {
                     Token::ClosedCurlyBrace() => break,
                     Token::Colon() => {
                         match self.tokens.next() {
@@ -188,7 +188,7 @@ impl<'a> Parser<'a> {
                     Token::Comma() => id = "",
                     Token::Text(ref text) => id = text,
                     _ => continue,
-                }},
+                },
                 None => break,
             }
         }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -71,7 +71,7 @@ impl<'a> Iterator for Scanner<'a> {
                         Some('"') => {
                             value = Some(Token::Text(text_builder.to_string()));
                             break;
-                        },
+                        }
                         Some(ch) => text_builder.push(ch),
                         None => {
                             value = Some(Token::Text(text_builder.to_string()));

--- a/src/values.rs
+++ b/src/values.rs
@@ -14,6 +14,13 @@ pub enum Token {
     Indentation(u32),
     Text(String),
     DocType(),
+    OpenCurlyBrace(),
+    ClosedCurlyBrace(),
+    Colon(),
+    Arrow(),
+    OpenBrace(),
+    ClosedBrace(),
+    Comma(),
 }
 
 impl Token {
@@ -31,6 +38,11 @@ impl Token {
             '#' => true,
             '\n' => true,
             '\r' => true,
+            '{' => true,
+            '}' => true,
+            ':' => true,
+            '[' => true,
+            ']' => true,
             _ => false,
         }
     }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -8,6 +8,13 @@ fn test(input_file: &str, expected_output_file: &str) {
     assert_eq!(html, actual_html);
 }
 
+fn test_debug(input_file: &str) {
+    let haml = &common::read_file(input_file);
+    let tokens = haml::tokenize(haml);
+    println!("{:?}", tokens);
+    assert!(false)
+}
+
 #[test]
 fn test_basic_haml() {
     test("tests/inputs/basic.haml", "tests/outputs/basic.html");
@@ -16,4 +23,9 @@ fn test_basic_haml() {
 #[test]
 fn test_custom_elements() {
     test("tests/inputs/custom.haml", "tests/outputs/custom.html");
+}
+
+#[test]
+fn test_ruby_attributes() {
+    test("tests/inputs/ruby_attributes.haml", "tests/outputs/ruby_attributes.html");
 }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -27,5 +27,8 @@ fn test_custom_elements() {
 
 #[test]
 fn test_ruby_attributes() {
-    test("tests/inputs/ruby_attributes.haml", "tests/outputs/ruby_attributes.html");
+    test(
+        "tests/inputs/ruby_attributes.haml",
+        "tests/outputs/ruby_attributes.html",
+    );
 }

--- a/tests/inputs/ruby_attributes.haml
+++ b/tests/inputs/ruby_attributes.haml
@@ -1,0 +1,6 @@
+!!! 5
+.container
+    %span{:id => "test", :class => "box"}
+        Test
+        %a{:href => "http://www.google.com", :class => ["active-link", "button"]}
+            Google

--- a/tests/inputs/ruby_attributes.haml
+++ b/tests/inputs/ruby_attributes.haml
@@ -2,5 +2,5 @@
 .container
     %span{:id => "test", :class => "box"}
         Test
-        %a{:href => "http://www.google.com", :class => ["active-link", "button"]}
+        %a{:href => "http://www.google.com", :class => ["button", "active-link"]}
             Google

--- a/tests/outputs/ruby_attributes.html
+++ b/tests/outputs/ruby_attributes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<div class='container'>
+<span class='box' id='test'>
+Test
+<a class='active-link button' href='http://www.google.com'>
+Google
+</a>
+</span>
+</div>

--- a/tests/outputs/ruby_attributes.html
+++ b/tests/outputs/ruby_attributes.html
@@ -2,7 +2,7 @@
 <div class='container'>
 <span class='box' id='test'>
 Test
-<a class='active-link button' href='http://www.google.com'>
+<a class='button active-link' href='http://www.google.com'>
 Google
 </a>
 </span>


### PR DESCRIPTION
In [Issue 7](https://github.com/jhartwell/haml-rs/issues/7) we need to add Ruby style attributes which are using {} instead of () and use Ruby dictionary syntax. This has been added.

One thing to note: may need to get a better way of sorting attributes. The reference Haml implementation sorts attributes alphabetically and so that had to be implemented as well but the naive implementation is cloning the keys, pushing into vec and then sorting that.